### PR TITLE
use `EMBER_ENV` to configure build enviroment for `ember build`

### DIFF
--- a/buildpack/mrbgem.rake
+++ b/buildpack/mrbgem.rake
@@ -11,6 +11,7 @@ MRuby::Gem::Specification.new('buildpack') do |spec|
   spec.add_dependency 'mruby-iijson',           mgem: 'mruby-iijson'
   spec.add_dependency 'mruby-md5',              mgem: 'mruby-md5'
   spec.add_dependency 'mruby-set',              mgem: 'mruby-set'
+  spec.add_dependency 'mruby-shellwords',       mgem: 'mruby-shellwords'
   spec.add_dependency 'mruby-docopt',           github: 'hone/mruby-docopt'
   spec.add_dependency 'mruby-fileutils-simple', github: 'hone/mruby-fileutils-simple'
   spec.add_dependency 'mruby-io',               github: 'hone/mruby-io',              branch: 'popen_status'

--- a/buildpack/mrblib/buildpack/commands/compile.rb
+++ b/buildpack/mrblib/buildpack/commands/compile.rb
@@ -37,7 +37,7 @@ module Buildpack
 
           tuple =
             if dependencies["ember-cli-deploy"]
-              EmberBuildTuple.new(true, "ember deploy #{@env["EMBER_ENV"]}", StaticConfig::DEFAULT_EMBER_CLI_DEPLOY_DIR)
+              EmberBuildTuple.new(true, "ember deploy #{Shellwords.escape(@env["EMBER_ENV"])}", StaticConfig::DEFAULT_EMBER_CLI_DEPLOY_DIR)
             else
               EmberBuildTuple.new(false, "ember build", StaticConfig::DEFAULT_EMBER_CLI_DIR)
             end

--- a/buildpack/mrblib/buildpack/commands/compile.rb
+++ b/buildpack/mrblib/buildpack/commands/compile.rb
@@ -26,6 +26,8 @@ module Buildpack
 
       def run
         Dir.chdir(@build_dir) do
+          @env["EMBER_ENV"] ||= "production"
+
           Bower.new(@output_io, @error_io, @cache).install
 
           unless command_success?("ember version 2> /dev/null")
@@ -35,9 +37,9 @@ module Buildpack
 
           tuple =
             if dependencies["ember-cli-deploy"]
-              EmberBuildTuple.new(true, "ember deploy production", StaticConfig::DEFAULT_EMBER_CLI_DEPLOY_DIR)
+              EmberBuildTuple.new(true, "ember deploy #{@env["EMBER_ENV"]}", StaticConfig::DEFAULT_EMBER_CLI_DEPLOY_DIR)
             else
-              EmberBuildTuple.new(false, "ember build --environment production", StaticConfig::DEFAULT_EMBER_CLI_DIR)
+              EmberBuildTuple.new(false, "ember build", StaticConfig::DEFAULT_EMBER_CLI_DIR)
             end
 
           @output_io.topic "Building ember assets"


### PR DESCRIPTION
This allows people to set non production environments, but still
defaults to production. See #3 for discussion.

You should be able to test it by setting your buildpack to:

```
$ heroku buildpacks:set https://codon-buildpacks.s3.amazonaws.com/buildpacks/hone/emberjs.tgz
```
