### PR TITLE
Add early return when no bower.json

### DIFF
--- a/buildpack/mrblib/buildpack/commands/compile/bower.rb
+++ b/buildpack/mrblib/buildpack/commands/compile/bower.rb
@@ -11,6 +11,11 @@ class Buildpack::Commands::Compile::Bower
   end
 
   def install
+    unless File.exist?(BOWER_JSON)
+      @output_io.topic "Skipping installing bower dependencies, no bower.json detected."
+      return
+    end
+
     unless command_success?("bower -v 2> /dev/null")
       @output_io.topic "Installing bower"
       pipe_exit_on_error("npm install -g bower", @output_io, @error_io, @env)


### PR DESCRIPTION
Hey, this is more a preliminary inquiry than a true PR, depending on your interest. I recently updated an application to Ember CLI 2.13, which no longer includes `bower.json` in the default blueprint. My application [failed to deploy on Heroku](https://travis-ci.org/backspace/prison-rideshare-ui/jobs/227687162#L2544) because of Bower throwing an error related to the missing file.

Do you think it makes sense to add support for Ember CLI applications with no `bower.json`? Should I add something like `@output_io.topic "Skipping installing bower dependencies, no bower.json"`?