### PR TITLE
Added support to customize Ember env during build

### DIFF
--- a/buildpack/mrbgem.rake
+++ b/buildpack/mrbgem.rake
@@ -11,6 +11,7 @@ MRuby::Gem::Specification.new('buildpack') do |spec|
   spec.add_dependency 'mruby-iijson',           mgem: 'mruby-iijson'
   spec.add_dependency 'mruby-md5',              mgem: 'mruby-md5'
   spec.add_dependency 'mruby-set',              mgem: 'mruby-set'
+  spec.add_dependency 'mruby-shellwords',       mgem: 'mruby-shellwords'
   spec.add_dependency 'mruby-tempfile',         mgem: 'tempfile'
   spec.add_dependency 'mruby-docopt',           github: 'hone/mruby-docopt'
   spec.add_dependency 'mruby-fileutils-simple', github: 'hone/mruby-fileutils-simple'

--- a/buildpack/mrblib/buildpack/commands/compile.rb
+++ b/buildpack/mrblib/buildpack/commands/compile.rb
@@ -34,12 +34,14 @@ module Buildpack
           end
 
           dependencies = Dependencies.new(@build_dir)
+          ember_env = Shellwords.escape(@env.fetch("EMBER_ENV", StaticConfig::DEFAULT_EMBER_ENV))
 
           tuple =
             if dependencies["ember-cli-deploy"]
-              EmberBuildTuple.new(true, "ember deploy production", StaticConfig::DEFAULT_EMBER_CLI_DEPLOY_DIR)
+              ember_cli_deploy_target = Shellwords.escape(@env.fetch("EMBER_CLI_DEPLOY_TARGET", ember_env))
+              EmberBuildTuple.new(true, "ember deploy #{ember_cli_deploy_target}", StaticConfig::DEFAULT_EMBER_CLI_DEPLOY_DIR)
             else
-              EmberBuildTuple.new(false, "ember build --environment production", StaticConfig::DEFAULT_EMBER_CLI_DIR)
+              EmberBuildTuple.new(false, "ember build --environment #{ember_env}", StaticConfig::DEFAULT_EMBER_CLI_DEPLOY_DIR)
             end
 
           @output_io.topic "Building ember assets"

--- a/buildpack/mrblib/buildpack/static_config.rb
+++ b/buildpack/mrblib/buildpack/static_config.rb
@@ -2,6 +2,7 @@ module Buildpack
   class StaticConfig
     DEFAULT_EMBER_CLI_DEPLOY_DIR = "tmp/deploy-dist"
     DEFAULT_EMBER_CLI_DIR        = "dist"
+    DEFAULT_EMBER_ENV            = "production"
     WRITEABLE_KEYS               = Set.new(%w(root routes))
 
     def initialize(contents = "{}", ember_cli_deploy = false)


### PR DESCRIPTION
This PR gathers all changes from #5 (including comments).

When I run `docker-compose run mtest && docker-compose run bintest` locally there are some red specs but I believe (please correct me if I'm wrong) they are not related to any changes here:

```
Finished tests in 0.232378s, 60.2467 tests/s, 150.6167 assertions/s.

14 tests, 35 assertions, 0 failures, 0 errors, 0 skips
trace:
        [1] /home/mruby/code/test/buildpack/commands/compile/test_cache.rb:2
        [0] /home/mruby/code/test/buildpack/commands/compile/test_cache.rb:1
/home/mruby/code/test/buildpack/commands/compile/test_cache.rb:2: uninitialized constant Buildpack::Commands::Compile::Cache (NameError)
...........................................................rake aborted!
```